### PR TITLE
Fix for cache file for different scopes

### DIFF
--- a/spotipy/util.py
+++ b/spotipy/util.py
@@ -62,7 +62,7 @@ def prompt_for_user_token(username, scope=None, client_id = None,
         ''')
         raise spotipy.SpotifyException(550, -1, 'no credentials set')
 
-    cache_path = cache_path or ".cache-" + username
+    cache_path = cache_path or ".cache-" + username + "-" + str(scope)
     sp_oauth = oauth2.SpotifyOAuth(client_id, client_secret, redirect_uri, 
         scope=scope, cache_path=cache_path)
 


### PR DESCRIPTION
Recommended fix in accordance with https://github.com/plamere/spotipy/issues/321, as outlined in the issue there when a token of a different scope is requested it triggers the browser launch due to the cache file being overwritten.