### PR TITLE
Make import statements explicit relative imports

### DIFF
--- a/spotipy/__init__.py
+++ b/spotipy/__init__.py
@@ -1,5 +1,5 @@
 VERSION='2.4.5'
 
-from client import *
-from oauth2 import *
-from util import *
+from .client import *
+from .oauth2 import *
+from .util import *


### PR DESCRIPTION
For me at least, in Python 3, the library fails to import, in that `import spotipy` fails with `ModuleNotFoundError: No module named 'oauth2'`. I believe this is because implicit relative imports aren't permitted in Python 3. This pull request changes the import statements in `__init__.py` to explicit relative imports.

This has the effect of reverting one of the changes in plamere/spotipy#257, which changed the `__init__.py` imports to implicit relative imports. Tagging @sr-murthy in case there's something about this change that I've missed.

I don't know what effect this would have on Python 2, but I believe explicit relative imports are supported in at least Python 2.7?

Thanks for picking up the initiative on this repository!